### PR TITLE
refactor taxonomies saving process

### DIFF
--- a/includes/class-cf7-2-post-factory.php
+++ b/includes/class-cf7-2-post-factory.php
@@ -1441,8 +1441,9 @@ class Cf7_2_Post_Factory {
       $value = isset($cf7_form_data[$form_field]) ? $cf7_form_data[$form_field] : '';
       $filter_name = $form_field;
       
-      if ( strpos($form_field, 'cf7_2_post_filter-') === false ) {
-        $filter_name = 'cf7_2_post_filter-' + $form_field;
+      // more specific filter names for menu fields
+      if ( strpos($filter_name, 'cf7_2_post_filter-') === false ) {
+        $filter_name = 'cf7_2_post_filter-' + $filter_name;
       }
       
       /**
@@ -1456,8 +1457,23 @@ class Cf7_2_Post_Factory {
        */
       $value = apply_filters($filter_name, $value, $post_id, $cf7_form_data);
 
+      // cleanup to array
+      if ( !is_array($value) ) {
+        $value = array($value);
+      }
+      $value = array_filter($value);
+      
       if ( !empty($value) ) {
+      
+        // Check for IDs in strings
+        array_walk($value, function(&$value_item){
+          if ( ctype_digit($value_item) ) {
+            $value_item = intval($value_item);
+          }
+        });
+        
         $term_taxonomy_ids = wp_set_object_terms($post_id, $value, $taxonomy);
+        
         if ( is_wp_error($term_taxonomy_ids) ) {
           debug_msg($term_taxonomy_ids, 'Unable to set taxonomy "' . $taxonomy . '" terms');
           debug_msg($value, 'Attempted to set these term values');

--- a/includes/class-cf7-2-post-factory.php
+++ b/includes/class-cf7-2-post-factory.php
@@ -1436,23 +1436,30 @@ class Cf7_2_Post_Factory {
     //
     //--------------- taxonomies
     //
-    foreach($this->post_map_taxonomy as $form_field => $taxonomy){
+    foreach ( $this->post_map_taxonomy as $form_field => $taxonomy ) {      
       $value = '';
-      if( 0 === strpos($form_field,'cf7_2_post_filter-') ) {
-        $value = apply_filters($form_field, array(), $post_id, $cf7_form_data);
-      }else if(isset( $cf7_form_data[$form_field] )){
-        if( is_array( $cf7_form_data[$form_field] ) ){
-          $value = array_map( 'intval', $cf7_form_data[$form_field] );
-        }else{
-          //debug_msg($cf7_form_data[$form_field], $taxonomy." values ");
-          $value = array_map( 'intval',  array( $cf7_form_data[$form_field] ) );
-        }
+      
+      if ( isset($cf7_form_data[$form_field]) ) {
+        // string|int|array $terms
+        $value = $cf7_form_data[$form_field];
       }
-      if( !empty($value) ){
-        $term_taxonomy_ids = wp_set_object_terms( $post_id , $value, $taxonomy );
-        if ( is_wp_error( $term_taxonomy_ids ) ) {
-        	debug_msg($term_taxonomy_ids, " Unable to set taxonomy (".$taxonomy.") terms");
-          debug_msg($value, "Attempted to set these term values ");
+      
+      /**
+       * Filter introduced for plugin developers to map custom plugin tag fields, allows for submitted values to be filtered before being stored.
+       * @since 
+       * @param mixed  $value          string|int|array $terms  post field value to return, by default it is empty. If you are filtering a taxonomy you can return either slug/id/array.  in case of ids make sure to cast them integers.(see https://codex.wordpress.org/Function_Reference/wp_set_object_terms for more information.)
+       * @param int    $post_id        ID of the post to which the form values are being mapped to
+       * @param array  $cf7_form_data  Submitted form data as an array of field-name=>value pairs Access current field with $cf7_form_data[$form_field]
+       * 
+       * @return mixed  $value  string|int|array $terms
+       */
+      $value = apply_filters($form_field, $value, $post_id, $cf7_form_data);
+      
+      if( !empty($value) ) {
+        $term_taxonomy_ids = wp_set_object_terms($post_id, $value, $taxonomy);
+        if ( is_wp_error($term_taxonomy_ids) ) {
+          debug_msg($term_taxonomy_ids, ' Unable to set taxonomy "' . $taxonomy . '" terms');
+          debug_msg($value, 'Attempted to set these term values');
         }
       }
     }

--- a/includes/class-cf7-2-post-factory.php
+++ b/includes/class-cf7-2-post-factory.php
@@ -1439,6 +1439,11 @@ class Cf7_2_Post_Factory {
     foreach ( $this->post_map_taxonomy as $form_field => $taxonomy ) {
       
       $value = isset($cf7_form_data[$form_field]) ? $cf7_form_data[$form_field] : '';
+      $filter_name = $form_field;
+      
+      if ( strpos($form_field, 'cf7_2_post_filter-') === false ) {
+        $filter_name = 'cf7_2_post_filter-' + $form_field;
+      }
       
       /**
        * Filter introduced for plugin developers to map custom plugin tag fields, allows for submitted values to be filtered before being stored.
@@ -1449,13 +1454,13 @@ class Cf7_2_Post_Factory {
        * 
        * @return mixed  $value  string|int|array $terms
        */
-      $value = apply_filters($form_field, $value, $post_id, $cf7_form_data);
-      
+      $value = apply_filters($filter_name, $value, $post_id, $cf7_form_data);
+
       if ( !empty($value) ) {
         $term_taxonomy_ids = wp_set_object_terms($post_id, $value, $taxonomy);
         if ( is_wp_error($term_taxonomy_ids) ) {
-          debug_msg($term_taxonomy_ids, " Unable to set taxonomy (".$taxonomy.") terms");
-          debug_msg($value, "Attempted to set these term values ");
+          debug_msg($term_taxonomy_ids, 'Unable to set taxonomy "' . $taxonomy . '" terms');
+          debug_msg($value, 'Attempted to set these term values');
         }
       }
     }

--- a/includes/class-cf7-2-post-factory.php
+++ b/includes/class-cf7-2-post-factory.php
@@ -1443,7 +1443,7 @@ class Cf7_2_Post_Factory {
       
       // more specific filter names for menu fields
       if ( strpos($filter_name, 'cf7_2_post_filter-') === false ) {
-        $filter_name = 'cf7_2_post_filter-' + $filter_name;
+        $filter_name = 'cf7_2_post_filter-' . $filter_name;
       }
       
       /**

--- a/includes/class-cf7-2-post-factory.php
+++ b/includes/class-cf7-2-post-factory.php
@@ -1436,13 +1436,9 @@ class Cf7_2_Post_Factory {
     //
     //--------------- taxonomies
     //
-    foreach ( $this->post_map_taxonomy as $form_field => $taxonomy ) {      
-      $value = '';
+    foreach ( $this->post_map_taxonomy as $form_field => $taxonomy ) {
       
-      if ( isset($cf7_form_data[$form_field]) ) {
-        // string|int|array $terms
-        $value = $cf7_form_data[$form_field];
-      }
+      $value = isset($cf7_form_data[$form_field]) ? $cf7_form_data[$form_field] : '';
       
       /**
        * Filter introduced for plugin developers to map custom plugin tag fields, allows for submitted values to be filtered before being stored.
@@ -1455,11 +1451,11 @@ class Cf7_2_Post_Factory {
        */
       $value = apply_filters($form_field, $value, $post_id, $cf7_form_data);
       
-      if( !empty($value) ) {
+      if ( !empty($value) ) {
         $term_taxonomy_ids = wp_set_object_terms($post_id, $value, $taxonomy);
         if ( is_wp_error($term_taxonomy_ids) ) {
-          debug_msg($term_taxonomy_ids, ' Unable to set taxonomy "' . $taxonomy . '" terms');
-          debug_msg($value, 'Attempted to set these term values');
+          debug_msg($term_taxonomy_ids, " Unable to set taxonomy (".$taxonomy.") terms");
+          debug_msg($value, "Attempted to set these term values ");
         }
       }
     }


### PR DESCRIPTION
Remove integer validation that does not work when slugs are used. Using slugs is OK for `wp_set_object_terms()` [Docs](https://developer.wordpress.org/reference/functions/wp_set_object_terms/). Also mixing with array seems no problem. We can rely on the API to take it.

I simple added the filter at the end anyway so the filter can be used at all time even if you are using a select-menu field.
I don't know how that would change the interface to add hooks or fields but that does not seem to work at all.

With that code i managed to get my [custom dynamic dropdown](https://github.com/netzgestaltung/wordpress-snippets/blob/master/wpcf7_form_tag.php) using slugs inserted into the post.
